### PR TITLE
Port mini program to Android skeleton

### DIFF
--- a/android-app/app/build.gradle
+++ b/android-app/app/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.landlordmanager'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.landlordmanager'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/android-app/app/proguard-rules.pro
+++ b/android-app/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add custom ProGuard rules here

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.landlordmanager">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="LandlordManager"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        <activity android:name=".ReceiptActivity" />
+        <activity android:name=".BillDetailActivity" />
+        <activity android:name=".BillListActivity" />
+        <activity android:name=".AddBillActivity" />
+        <activity android:name=".EditTenantActivity" />
+        <activity android:name=".AddTenantActivity" />
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android-app/app/src/main/java/com/example/landlordmanager/AddBillActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/AddBillActivity.kt
@@ -1,0 +1,37 @@
+package com.example.landlordmanager
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class AddBillActivity : AppCompatActivity() {
+    private lateinit var repository: DataRepository
+    private var roomNumber: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_bill)
+
+        repository = DataRepository(this)
+        roomNumber = intent.getStringExtra("room") ?: ""
+
+        val month = findViewById<EditText>(R.id.edit_month)
+        val waterCurrent = findViewById<EditText>(R.id.edit_water_current)
+        val electricCurrent = findViewById<EditText>(R.id.edit_electric_current)
+
+        findViewById<Button>(R.id.button_save_bill).setOnClickListener {
+            val bill = Bill(
+                month.text.toString(),
+                waterCurrent.text.toString().toDoubleOrNull() ?: 0.0,
+                0.0,
+                0.0,
+                electricCurrent.text.toString().toDoubleOrNull() ?: 0.0,
+                0.0,
+                0.0
+            )
+            repository.saveBill(roomNumber, bill)
+            finish()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/AddTenantActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/AddTenantActivity.kt
@@ -1,0 +1,32 @@
+package com.example.landlordmanager
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class AddTenantActivity : AppCompatActivity() {
+
+    private lateinit var repository: DataRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_tenant)
+
+        repository = DataRepository(this)
+
+        val name = findViewById<EditText>(R.id.edit_name)
+        val room = findViewById<EditText>(R.id.edit_room)
+        val rent = findViewById<EditText>(R.id.edit_rent)
+
+        findViewById<Button>(R.id.button_save).setOnClickListener {
+            val tenant = Tenant(
+                name.text.toString(),
+                room.text.toString(),
+                rent.text.toString().toDoubleOrNull() ?: 0.0
+            )
+            repository.addTenant(tenant)
+            finish()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/Bill.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/Bill.kt
@@ -1,0 +1,11 @@
+package com.example.landlordmanager
+
+data class Bill(
+    var month: String,
+    var waterCurrent: Double,
+    var waterPrevious: Double,
+    var waterAmount: Double,
+    var electricityCurrent: Double,
+    var electricityPrevious: Double,
+    var electricityAmount: Double
+)

--- a/android-app/app/src/main/java/com/example/landlordmanager/BillDetailActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/BillDetailActivity.kt
@@ -1,0 +1,24 @@
+package com.example.landlordmanager
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+class BillDetailActivity : AppCompatActivity() {
+    private lateinit var repository: DataRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_bill_detail)
+
+        repository = DataRepository(this)
+        val room = intent.getStringExtra("room") ?: return
+        val month = intent.getStringExtra("month") ?: return
+
+        val bill = repository.getBills(room).find { it.month == month }
+        val text = findViewById<TextView>(R.id.text_bill_detail)
+        text.text = bill?.let {
+            "Room $room\nMonth: ${it.month}\nWater: ${it.waterCurrent}\nElectricity: ${it.electricityCurrent}"
+        } ?: "No data"
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/BillListActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/BillListActivity.kt
@@ -1,0 +1,37 @@
+package com.example.landlordmanager
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+class BillListActivity : AppCompatActivity() {
+    private lateinit var repository: DataRepository
+    private lateinit var adapter: BillListAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_bill_list)
+
+        repository = DataRepository(this)
+        adapter = BillListAdapter(emptyList()) { bill, room ->
+            val intent = Intent(this, BillDetailActivity::class.java)
+            intent.putExtra("room", room)
+            intent.putExtra("month", bill.month)
+            startActivity(intent)
+        }
+
+        val recycler = findViewById<RecyclerView>(R.id.recycler_bills)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = adapter
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val allBills = repository.getTenants().flatMap { tenant ->
+            repository.getBills(tenant.roomNumber).map { bill -> tenant.roomNumber to bill }
+        }
+        adapter.updateData(allBills)
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/BillListAdapter.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/BillListAdapter.kt
@@ -1,0 +1,36 @@
+package com.example.landlordmanager
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class BillListAdapter(
+    private var items: List<Pair<String, Bill>>,
+    private val onClick: (Bill, String) -> Unit
+) : RecyclerView.Adapter<BillListAdapter.VH>() {
+
+    class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val text: TextView = itemView.findViewById(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return VH(view)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val (room, bill) = items[position]
+        holder.text.text = "${bill.month} - Room $room"
+        holder.itemView.setOnClickListener { onClick(bill, room) }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun updateData(newItems: List<Pair<String, Bill>>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/DataRepository.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/DataRepository.kt
@@ -1,0 +1,72 @@
+package com.example.landlordmanager
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class DataRepository(private val context: Context) {
+    private val prefs = context.getSharedPreferences("landlord_data", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    private var tenants: MutableList<Tenant> = loadTenants()
+    private var bills: MutableMap<String, MutableList<Bill>> = loadBills()
+
+    private fun loadTenants(): MutableList<Tenant> {
+        val json = prefs.getString("tenants", null)
+        return if (json != null) {
+            val type = object : TypeToken<MutableList<Tenant>>() {}.type
+            gson.fromJson(json, type)
+        } else {
+            mutableListOf()
+        }
+    }
+
+    private fun loadBills(): MutableMap<String, MutableList<Bill>> {
+        val json = prefs.getString("bills", null)
+        return if (json != null) {
+            val type = object : TypeToken<MutableMap<String, MutableList<Bill>>>() {}.type
+            gson.fromJson(json, type)
+        } else {
+            mutableMapOf()
+        }
+    }
+
+    private fun saveTenants() {
+        prefs.edit().putString("tenants", gson.toJson(tenants)).apply()
+    }
+
+    private fun saveBills() {
+        prefs.edit().putString("bills", gson.toJson(bills)).apply()
+    }
+
+    fun getTenants(): List<Tenant> = tenants
+
+    fun addTenant(tenant: Tenant) {
+        tenants.add(tenant)
+        saveTenants()
+    }
+
+    fun updateTenant(originalRoom: String, updated: Tenant) {
+        val index = tenants.indexOfFirst { it.roomNumber == originalRoom }
+        if (index >= 0) {
+            tenants[index] = updated
+            saveTenants()
+        }
+    }
+
+    fun deleteTenant(roomNumber: String) {
+        tenants.removeAll { it.roomNumber == roomNumber }
+        bills.remove(roomNumber)
+        saveTenants()
+        saveBills()
+    }
+
+    fun saveBill(roomNumber: String, bill: Bill) {
+        val list = bills.getOrPut(roomNumber) { mutableListOf() }
+        list.removeAll { it.month == bill.month }
+        list.add(bill)
+        saveBills()
+    }
+
+    fun getBills(roomNumber: String): List<Bill> = bills[roomNumber] ?: emptyList()
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/EditTenantActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/EditTenantActivity.kt
@@ -1,0 +1,41 @@
+package com.example.landlordmanager
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class EditTenantActivity : AppCompatActivity() {
+
+    private lateinit var repository: DataRepository
+    private var originalRoom: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_edit_tenant)
+
+        repository = DataRepository(this)
+        originalRoom = intent.getStringExtra("room") ?: ""
+        val tenant = repository.getTenants().find { it.roomNumber == originalRoom }
+
+        val name = findViewById<EditText>(R.id.edit_name)
+        val room = findViewById<EditText>(R.id.edit_room)
+        val rent = findViewById<EditText>(R.id.edit_rent)
+
+        tenant?.let {
+            name.setText(it.name)
+            room.setText(it.roomNumber)
+            rent.setText(it.rent.toString())
+        }
+
+        findViewById<Button>(R.id.button_save).setOnClickListener {
+            val updated = Tenant(
+                name.text.toString(),
+                room.text.toString(),
+                rent.text.toString().toDoubleOrNull() ?: 0.0
+            )
+            repository.updateTenant(originalRoom, updated)
+            finish()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/MainActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/MainActivity.kt
@@ -1,0 +1,43 @@
+package com.example.landlordmanager
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.button.MaterialButton
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var repository: DataRepository
+    private lateinit var adapter: TenantAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        repository = DataRepository(this)
+        adapter = TenantAdapter(repository.getTenants()) { tenant ->
+            val intent = Intent(this, EditTenantActivity::class.java)
+            intent.putExtra("room", tenant.roomNumber)
+            startActivity(intent)
+        }
+
+        val recycler = findViewById<RecyclerView>(R.id.recycler_tenants)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = adapter
+
+        findViewById<MaterialButton>(R.id.button_add_tenant).setOnClickListener {
+            startActivity(Intent(this, AddTenantActivity::class.java))
+        }
+
+        findViewById<MaterialButton>(R.id.button_bill_list).setOnClickListener {
+            startActivity(Intent(this, BillListActivity::class.java))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        adapter.updateData(repository.getTenants())
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/ReceiptActivity.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/ReceiptActivity.kt
@@ -1,0 +1,24 @@
+package com.example.landlordmanager
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+class ReceiptActivity : AppCompatActivity() {
+    private lateinit var repository: DataRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_receipt)
+
+        repository = DataRepository(this)
+        val room = intent.getStringExtra("room") ?: return
+        val bills = repository.getBills(room)
+        val latest = bills.maxByOrNull { it.month }
+
+        val text = findViewById<TextView>(R.id.text_receipt)
+        text.text = latest?.let {
+            "Receipt for Room $room\nMonth: ${it.month}\nWater: ${it.waterCurrent}\nElectricity: ${it.electricityCurrent}"
+        } ?: "No receipt"
+    }
+}

--- a/android-app/app/src/main/java/com/example/landlordmanager/Tenant.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/Tenant.kt
@@ -1,0 +1,7 @@
+package com.example.landlordmanager
+
+data class Tenant(
+    var name: String,
+    var roomNumber: String,
+    var rent: Double
+)

--- a/android-app/app/src/main/java/com/example/landlordmanager/TenantAdapter.kt
+++ b/android-app/app/src/main/java/com/example/landlordmanager/TenantAdapter.kt
@@ -1,0 +1,36 @@
+package com.example.landlordmanager
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class TenantAdapter(
+    private var items: List<Tenant>,
+    private val onClick: (Tenant) -> Unit
+) : RecyclerView.Adapter<TenantAdapter.VH>() {
+
+    class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val name: TextView = itemView.findViewById(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return VH(view)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val tenant = items[position]
+        holder.name.text = "${tenant.roomNumber} - ${tenant.name}"
+        holder.itemView.setOnClickListener { onClick(tenant) }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun updateData(newItems: List<Tenant>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+}

--- a/android-app/app/src/main/res/layout/activity_add_bill.xml
+++ b/android-app/app/src/main/res/layout/activity_add_bill.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/edit_month"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="YYYY-MM" />
+
+        <EditText
+            android:id="@+id/edit_water_current"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Water Current" />
+
+        <EditText
+            android:id="@+id/edit_electric_current"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Electric Current" />
+
+        <Button
+            android:id="@+id/button_save_bill"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Save Bill" />
+    </LinearLayout>
+</ScrollView>

--- a/android-app/app/src/main/res/layout/activity_add_tenant.xml
+++ b/android-app/app/src/main/res/layout/activity_add_tenant.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edit_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Name" />
+
+    <EditText
+        android:id="@+id/edit_room"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Room Number"
+        android:inputType="number" />
+
+    <EditText
+        android:id="@+id/edit_rent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Rent"
+        android:inputType="numberDecimal" />
+
+    <Button
+        android:id="@+id/button_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Save" />
+</LinearLayout>

--- a/android-app/app/src/main/res/layout/activity_bill_detail.xml
+++ b/android-app/app/src/main/res/layout/activity_bill_detail.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_bill_detail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/android-app/app/src/main/res/layout/activity_bill_list.xml
+++ b/android-app/app/src/main/res/layout/activity_bill_list.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_bills"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/android-app/app/src/main/res/layout/activity_edit_tenant.xml
+++ b/android-app/app/src/main/res/layout/activity_edit_tenant.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edit_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Name" />
+
+    <EditText
+        android:id="@+id/edit_room"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Room Number"
+        android:inputType="number" />
+
+    <EditText
+        android:id="@+id/edit_rent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Rent"
+        android:inputType="numberDecimal" />
+
+    <Button
+        android:id="@+id/button_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Save" />
+</LinearLayout>

--- a/android-app/app/src/main/res/layout/activity_main.xml
+++ b/android-app/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/button_add_tenant"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add Tenant" />
+
+    <Button
+        android:id="@+id/button_bill_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Bill List" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_tenants"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/android-app/app/src/main/res/layout/activity_receipt.xml
+++ b/android-app/app/src/main/res/layout/activity_receipt.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_receipt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/android-app/app/src/main/res/values/colors.xml
+++ b/android-app/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">LandlordManager</string>
+</resources>

--- a/android-app/app/src/main/res/values/themes.xml
+++ b/android-app/app/src/main/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LandlordManager" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/purple_700</item>
+    </style>
+</resources>

--- a/android-app/build.gradle
+++ b/android-app/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'com.android.application' version '8.2.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android-app/settings.gradle
+++ b/android-app/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'LandlordApp'
+include ':app'


### PR DESCRIPTION
## Summary
- add `android-app` folder with Android Studio project
- implement basic data model and storage using `SharedPreferences`
- create activities for tenants, bills, and receipts
- provide simple XML layouts and manifest

## Testing
- `gradle wrapper` could not run due to missing Android Gradle plugin in offline environment

------
https://chatgpt.com/codex/tasks/task_e_68736ef35280832db123cf8e5c714f01